### PR TITLE
Sprint2/renaming

### DIFF
--- a/__test__/cli/drawBoard.test.js
+++ b/__test__/cli/drawBoard.test.js
@@ -1,9 +1,9 @@
 const drawBoard = require('../../src/cli/drawBoard')
-const board = require('../../src/game/board')
+const referee = require('../../src/game/referee')
 
 describe('the display functions', () => {
   it('can display an empty board', () => {
-    const state = board.newState()
+    const board = referee.create()
     const expected = `\n+-----------+
 | 1 | 2 | 3 |
 +-----------+
@@ -12,13 +12,13 @@ describe('the display functions', () => {
 | 7 | 8 | 9 |
 +-----------+\n`
 
-    expect(drawBoard(state)).toEqual(expected)
+    expect(drawBoard(board)).toEqual(expected)
   })
-  it('can display an board with moves played', () => {
-    const state = board.newState()
-    const firstMove = board.update(state, 1, 'X')
-    const secondMove = board.update(firstMove, 5, 'O')
-    const thirdMove = board.update(secondMove, 9, 'X')
+  it('can display a boardwith moves played', () => {
+    const board = referee.create()
+    const firstMove = referee.update(board, 1, 'X')
+    const secondMove = referee.update(firstMove, 5, 'O')
+    const thirdMove = referee.update(secondMove, 9, 'X')
     const expected = `\n+-----------+
 | X | 2 | 3 |
 +-----------+

--- a/__test__/cli/drawBoard.test.js
+++ b/__test__/cli/drawBoard.test.js
@@ -1,32 +1,32 @@
-const display = require('../../src/cli/display')
+const drawBoard = require('../../src/cli/drawBoard')
 const board = require('../../src/game/board')
 
 describe('the display functions', () => {
   it('can display an empty board', () => {
     const state = board.newState()
-    const expected = `+-----------+
+    const expected = `\n+-----------+
 | 1 | 2 | 3 |
 +-----------+
 | 4 | 5 | 6 |
 +-----------+
 | 7 | 8 | 9 |
-+-----------+`
++-----------+\n`
 
-    expect(display.board(state)).toEqual(expected)
+    expect(drawBoard(state)).toEqual(expected)
   })
   it('can display an board with moves played', () => {
     const state = board.newState()
     const firstMove = board.update(state, 1, 'X')
     const secondMove = board.update(firstMove, 5, 'O')
     const thirdMove = board.update(secondMove, 9, 'X')
-    const expected = `+-----------+
+    const expected = `\n+-----------+
 | X | 2 | 3 |
 +-----------+
 | 4 | O | 6 |
 +-----------+
 | 7 | 8 | X |
-+-----------+`
++-----------+\n`
 
-    expect(display.board(thirdMove)).toEqual(expected)
+    expect(drawBoard(thirdMove)).toEqual(expected)
   })
 })

--- a/__test__/cli/index.test.js
+++ b/__test__/cli/index.test.js
@@ -1,7 +1,7 @@
 const start = require('../../src/cli/index')
-const makeMove = require('../../src/cli/makeMove')
+const play = require('../../src/cli/play')
 
-jest.mock('../../src/cli/makeMove')
+jest.mock('../../src/cli/play')
 
 describe('the start function', () => {
   let options, write, updater, io
@@ -30,6 +30,6 @@ describe('the start function', () => {
 
   it('calls makeMove with three arguments', () => {
     start(options, updater, io)
-    expect(makeMove).toHaveBeenCalledWith(options, updater, io)
+    expect(play).toHaveBeenCalledWith(options, updater, io)
   })
 })

--- a/__test__/cli/index.test.js
+++ b/__test__/cli/index.test.js
@@ -4,7 +4,7 @@ const play = require('../../src/cli/play')
 jest.mock('../../src/cli/play')
 
 describe('the start function', () => {
-  let options, write, updater, io
+  let options, write, io
   beforeEach(() => {
     options = {
       messages: {
@@ -13,7 +13,6 @@ describe('the start function', () => {
         instructions: 'instructions',
       },
     }
-    updater = jest.fn()
     write = jest.fn()
     io = {
       write,
@@ -21,15 +20,15 @@ describe('the start function', () => {
   })
 
   it('writes the title, intro and instructions messages', () => {
-    start(options, updater, io)
+    start(options, io)
     expect(write).toHaveBeenCalledTimes(3)
     expect(write.mock.calls[0][0]).toEqual('title')
     expect(write.mock.calls[1][0]).toEqual('intro')
     expect(write.mock.calls[2][0]).toEqual('instructions')
   })
 
-  it('calls makeMove with three arguments', () => {
-    start(options, updater, io)
-    expect(play).toHaveBeenCalledWith(options, updater, io)
+  it('calls makeMove with two arguments', () => {
+    start(options, io)
+    expect(play).toHaveBeenCalledWith(options, io)
   })
 })

--- a/__test__/cli/play.test.js
+++ b/__test__/cli/play.test.js
@@ -14,7 +14,7 @@ describe('the makeMove function', () => {
 
     game.init.mockReturnValue({
       isActive: true,
-      state: [],
+      board: [],
       messages: {
         turn: 'test',
       },

--- a/__test__/cli/play.test.js
+++ b/__test__/cli/play.test.js
@@ -1,4 +1,4 @@
-const makeMove = require('../../src/cli/makeMove')
+const play = require('../../src/cli/play')
 const gameOver = require('../../src/cli/gameOver')
 const getMove = require('../../src/cli/getMove')
 const game = require('../../src/game')
@@ -34,21 +34,21 @@ describe('the makeMove function', () => {
   })
 
   it('draws the board', () => {
-    makeMove(options, game.update, io)
+    play(options, game.update, io)
     expect(write).toHaveBeenCalled()
   })
 
   it('calls gameOver if the game is finished', () => {
     options.isActive = false
 
-    makeMove(options, game.update, io)
+    play(options, game.update, io)
     expect(gameOver).toHaveBeenCalled()
   })
 
   it('will call itself recursively until the game is over', async () => {
     const userInput = '5'
     getMove.mockResolvedValue(userInput)
-    await makeMove(options, game.update, io)
+    await play(options, game.update, io)
     expect(gameOver).toHaveBeenCalled()
   })
 })

--- a/__test__/cli/play.test.js
+++ b/__test__/cli/play.test.js
@@ -34,21 +34,21 @@ describe('the makeMove function', () => {
   })
 
   it('draws the board', () => {
-    play(options, game.update, io)
+    play(options, io)
     expect(write).toHaveBeenCalled()
   })
 
   it('calls gameOver if the game is finished', () => {
     options.isActive = false
 
-    play(options, game.update, io)
+    play(options, io)
     expect(gameOver).toHaveBeenCalled()
   })
 
   it('will call itself recursively until the game is over', async () => {
     const userInput = '5'
     getMove.mockResolvedValue(userInput)
-    await play(options, game.update, io)
+    await play(options, io)
     expect(gameOver).toHaveBeenCalled()
   })
 })

--- a/__test__/cli/utils/state.test.js
+++ b/__test__/cli/utils/state.test.js
@@ -1,25 +1,25 @@
 const { get } = require('../../../src/cli/utils/state')
-const board = require('../../../src/game/board')
+const referee = require('../../../src/game/referee')
 
 describe('the get function', () => {
   it('can retreive the contents of board square', () => {
-    let state = board.newState()
+    let board = referee.create()
     const position = 1
-    state = board.update(state, position, 'X')
-    expect(get(state, position)).toEqual('X')
+    board = referee.update(board, position, 'X')
+    expect(get(board, position)).toEqual('X')
   })
 
   it('returns the position if the square is empty', () => {
-    let state = board.newState()
+    let board = referee.create()
     const position = 9
 
-    expect(get(state, position)).toEqual(9)
+    expect(get(board, position)).toEqual(9)
   })
 
   it('will return any position even if it does not exist on the board', () => {
-    let state = board.newState()
+    let board = referee.create()
     const position = 100
 
-    expect(get(state, position)).toEqual(100)
+    expect(get(board, position)).toEqual(100)
   })
 })

--- a/__test__/game/ai/minimax.test.js
+++ b/__test__/game/ai/minimax.test.js
@@ -1,68 +1,68 @@
 const minimax = require('../../../src/game/ai/minimax')
-const board = require('../../../src/game/board')
+const referee = require('../../../src/game/referee')
 
 describe('the minimax algorithm', () => {
-  let state
+  let board
   beforeEach(() => {
-    state = board.newState()
+    board = referee.create()
   })
 
   it('throws an error if the board is full', () => {
-    state = board.update(state, 1, 'X')
-    state = board.update(state, 2, 'O')
-    state = board.update(state, 3, 'X')
-    state = board.update(state, 4, 'X')
-    state = board.update(state, 5, 'O')
-    state = board.update(state, 6, 'O')
-    state = board.update(state, 7, 'O')
-    state = board.update(state, 8, 'X')
-    state = board.update(state, 9, 'X')
+    board = referee.update(board, 1, 'X')
+    board = referee.update(board, 2, 'O')
+    board = referee.update(board, 3, 'X')
+    board = referee.update(board, 4, 'X')
+    board = referee.update(board, 5, 'O')
+    board = referee.update(board, 6, 'O')
+    board = referee.update(board, 7, 'O')
+    board = referee.update(board, 8, 'X')
+    board = referee.update(board, 9, 'X')
 
-    expect(() => minimax(state, 'X')).toThrow(TypeError)
+    expect(() => minimax(board, 'X')).toThrow(TypeError)
   })
 
   it('returns the last move left on the board if one move is available', () => {
-    state = board.update(state, 1, 'X')
-    state = board.update(state, 2, 'O')
-    state = board.update(state, 3, 'X')
-    state = board.update(state, 4, 'X')
-    state = board.update(state, 5, 'O')
-    state = board.update(state, 6, 'O')
-    state = board.update(state, 7, 'O')
-    state = board.update(state, 8, 'X')
+    board = referee.update(board, 1, 'X')
+    board = referee.update(board, 2, 'O')
+    board = referee.update(board, 3, 'X')
+    board = referee.update(board, 4, 'X')
+    board = referee.update(board, 5, 'O')
+    board = referee.update(board, 6, 'O')
+    board = referee.update(board, 7, 'O')
+    board = referee.update(board, 8, 'X')
     const position = 9
 
-    expect(minimax(state, 'X').position).toEqual(position)
+    expect(minimax(board, 'X').position).toEqual(position)
   })
 
   it('chooses a win over a draw with two squares available', () => {
-    state = board.update(state, 1, 'X')
-    state = board.update(state, 2, 'O')
-    state = board.update(state, 3, 'X')
-    state = board.update(state, 4, 'X')
-    state = board.update(state, 6, 'O')
-    state = board.update(state, 7, 'O')
-    state = board.update(state, 9, 'X')
+    board = referee.update(board, 1, 'X')
+    board = referee.update(board, 2, 'O')
+    board = referee.update(board, 3, 'X')
+    board = referee.update(board, 4, 'X')
+    board = referee.update(board, 6, 'O')
+    board = referee.update(board, 7, 'O')
+    board = referee.update(board, 9, 'X')
     const position = 5
 
-    expect(minimax(state, 'X').position).toEqual(position)
+    expect(minimax(board, 'X').position).toEqual(position)
   })
 
   it('avoids a loss', () => {
-    state = board.update(state, 1, 'X')
-    state = board.update(state, 2, 'X')
-    state = board.update(state, 3, 'O')
-    state = board.update(state, 5, 'O')
+    board = referee.update(board, 1, 'X')
+    board = referee.update(board, 2, 'X')
+    board = referee.update(board, 3, 'O')
+    board = referee.update(board, 5, 'O')
     const position = 7
 
-    expect(minimax(state, 'X').position).toEqual(position)
+    expect(minimax(board, 'X').position).toEqual(position)
   })
 
   it('works with both X and O marks as the maximising player', () => {
-    state = board.update(state, 1, 'O')
-    state = board.update(state, 2, 'O')
+    board = referee.update(board, 1, 'O')
+    board = referee.update(board, 2, 'O')
     const noughtWinningValue = 16
 
-    expect(minimax(state, 'O').value).toEqual(noughtWinningValue)
+    expect(minimax(board, 'O').value).toEqual(noughtWinningValue)
   })
 })

--- a/__test__/game/board.test.js
+++ b/__test__/game/board.test.js
@@ -1,64 +1,64 @@
-const board = require('../../src/game/board')
+const referee = require('../../src/game/referee')
 
-describe('The board class', () => {
-  describe('With board.newState()', () => {
+describe('The referee object', () => {
+  describe('With referee.create()', () => {
     it('Returns 9 moves by default', () => {
-      const state = board.newState()
-      expect(board.available(state)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9])
+      const board = referee.create()
+      expect(referee.available(board)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9])
     })
   })
 
-  describe('Using board.update()', () => {
+  describe('Using referee.update()', () => {
     it('Can retrieve a mark from a played square', () => {
-      const state = board.newState()
-      const updatedboard = board.update(state, 9, 'X')
-      expect(board.get(updatedboard, 9)).toEqual('X')
+      const state = referee.create()
+      const updatedboard = referee.update(state, 9, 'X')
+      expect(referee.get(updatedboard, 9)).toEqual('X')
     })
 
     it('Returns 8 moves if one has been played', () => {
-      const state = board.newState()
-      const updatedboard = board.update(state, 1, 'X')
-      expect(board.available(updatedboard)).toEqual([2, 3, 4, 5, 6, 7, 8, 9])
+      const state = referee.create()
+      const updatedboard = referee.update(state, 1, 'X')
+      expect(referee.available(updatedboard)).toEqual([2, 3, 4, 5, 6, 7, 8, 9])
     })
 
     it('Throws if the requested position is out of range', () => {
-      const state = board.newState()
+      const board = referee.create()
       const tooLow = 0
       const tooHigh = 10
 
-      expect(() => board.update(state, tooLow, 'X')).toThrow(RangeError)
-      expect(() => board.update(state, tooHigh, 'X')).toThrow(RangeError)
+      expect(() => referee.update(board, tooLow, 'X')).toThrow(RangeError)
+      expect(() => referee.update(board, tooHigh, 'X')).toThrow(RangeError)
     })
   })
 
   describe('Using board.hasWinner()', () => {
     it('Knows an state with no played moves has no winner', () => {
-      const state = board.newState()
-      expect(board.hasWinner(state)).toBe(false)
+      const board = referee.create()
+      expect(referee.hasWinner(board)).toBe(false)
     })
 
     it('Knows three played moves on a horizontal is a winning move', () => {
-      const state = board.newState()
-      const firstMove = board.update(state, 1, 'X')
-      const secondMove = board.update(firstMove, 2, 'X')
-      const thirdMove = board.update(secondMove, 3, 'X')
-      expect(board.hasWinner(thirdMove)).toBe(true)
+      const board = referee.create()
+      const firstMove = referee.update(board, 1, 'X')
+      const secondMove = referee.update(firstMove, 2, 'X')
+      const thirdMove = referee.update(secondMove, 3, 'X')
+      expect(referee.hasWinner(thirdMove)).toBe(true)
     })
 
     it('Knows three played moves on a vertical is a winning move', () => {
-      const state = board.newState()
-      const firstMove = board.update(state, 2, 'X')
-      const secondMove = board.update(firstMove, 5, 'X')
-      const thirdMove = board.update(secondMove, 8, 'X')
-      expect(board.hasWinner(thirdMove)).toBe(true)
+      const state = referee.create()
+      const firstMove = referee.update(state, 2, 'X')
+      const secondMove = referee.update(firstMove, 5, 'X')
+      const thirdMove = referee.update(secondMove, 8, 'X')
+      expect(referee.hasWinner(thirdMove)).toBe(true)
     })
 
     it('Knows three played moves on a diagonal is a winning move', () => {
-      const state = board.newState()
-      const firstMove = board.update(state, 3, 'X')
-      const secondMove = board.update(firstMove, 5, 'X')
-      const thirdMove = board.update(secondMove, 7, 'X')
-      expect(board.hasWinner(thirdMove)).toBe(true)
+      const state = referee.create()
+      const firstMove = referee.update(state, 3, 'X')
+      const secondMove = referee.update(firstMove, 5, 'X')
+      const thirdMove = referee.update(secondMove, 7, 'X')
+      expect(referee.hasWinner(thirdMove)).toBe(true)
     })
   })
 })

--- a/__test__/game/init.test.js
+++ b/__test__/game/init.test.js
@@ -6,8 +6,8 @@ describe('the game initialiser', () => {
     expect(newGame.isActive).toEqual(true)
   })
 
-  it('has a board state', () => {
-    expect(newGame.state).toBeDefined()
+  it('has a board', () => {
+    expect(newGame.board).toBeDefined()
   })
 
   it('contains the game messages', () => {

--- a/__test__/game/update.test.js
+++ b/__test__/game/update.test.js
@@ -1,15 +1,15 @@
 const update = require('../../src/game/update')
-const board = require('../../src/game/board')
+const referee = require('../../src/game/referee')
 const game = require('../../src/game')
 
 describe('the update function', () => {
-  it('updates the board state', () => {
+  it('updates the board', () => {
     const options = game.init()
     const position = 1
 
-    const { state } = update(position, options)
+    const { board } = update(position, options)
 
-    expect(board.get(state, position)).toEqual(options.currentPlayer)
+    expect(referee.get(board, position)).toEqual(options.currentPlayer)
   })
 
   it('swaps the players', () => {
@@ -67,6 +67,6 @@ describe('the update function', () => {
     const turnOneCross = update(1, turnZero)
 
     expect(turnOneCross.currentPlayer).toEqual('X')
-    expect(board.available(turnOneCross.state).length).toEqual(7)
+    expect(referee.available(turnOneCross.board).length).toEqual(7)
   })
 })

--- a/index.js
+++ b/index.js
@@ -14,6 +14,4 @@ if (process.argv[2] === '--mode' && process.argv[3] === 'ai') {
   mode = 'human'
 }
 
-const options = game.init(mode)
-
-start(options, io)
+start(game.init(mode), io)

--- a/index.js
+++ b/index.js
@@ -15,6 +15,5 @@ if (process.argv[2] === '--mode' && process.argv[3] === 'ai') {
 }
 
 const options = game.init(mode)
-const updater = game.update
 
-start(options, updater, io)
+start(options, io)

--- a/src/cli/drawBoard.js
+++ b/src/cli/drawBoard.js
@@ -1,20 +1,20 @@
 const { get } = require('./utils/state')
 
-module.exports = state =>
+module.exports = board =>
   [
     '',
     divider,
-    generateRow(state, [1, 2, 3]),
+    generateRow(board, [1, 2, 3]),
     divider,
-    generateRow(state, [4, 5, 6]),
+    generateRow(board, [4, 5, 6]),
     divider,
-    generateRow(state, [7, 8, 9]),
+    generateRow(board, [7, 8, 9]),
     divider,
     '',
   ].join('\n')
 
-const generateRow = (state, squares) => {
-  const generateSquare = position => get(state, position)
+const generateRow = (board, squares) => {
+  const generateSquare = position => get(board, position)
 
   return (
     '| ' +

--- a/src/cli/drawBoard.js
+++ b/src/cli/drawBoard.js
@@ -1,17 +1,17 @@
 const { get } = require('./utils/state')
 
-module.exports = {
-  board: state =>
-    [
-      divider,
-      generateRow(state, [1, 2, 3]),
-      divider,
-      generateRow(state, [4, 5, 6]),
-      divider,
-      generateRow(state, [7, 8, 9]),
-      divider,
-    ].join('\n'),
-}
+module.exports = state =>
+  [
+    '',
+    divider,
+    generateRow(state, [1, 2, 3]),
+    divider,
+    generateRow(state, [4, 5, 6]),
+    divider,
+    generateRow(state, [7, 8, 9]),
+    divider,
+    '',
+  ].join('\n')
 
 const generateRow = (state, squares) => {
   const generateSquare = position => get(state, position)

--- a/src/cli/gameOver.js
+++ b/src/cli/gameOver.js
@@ -1,9 +1,9 @@
 const drawBoard = require('./drawBoard')
 
 module.exports = (options, io) => {
-  const { state, messages } = options
+  const { board, messages } = options
   const { write } = io
 
-  write(drawBoard(state))
+  write(drawBoard(board))
   write(messages.ending)
 }

--- a/src/cli/gameOver.js
+++ b/src/cli/gameOver.js
@@ -1,7 +1,7 @@
 const drawBoard = require('./drawBoard')
 
-module.exports = (options, io) => {
-  const { board, messages } = options
+module.exports = (game, io) => {
+  const { board, messages } = game
   const { write } = io
 
   write(drawBoard(board))

--- a/src/cli/gameOver.js
+++ b/src/cli/gameOver.js
@@ -1,9 +1,9 @@
-const display = require('./display')
+const drawBoard = require('./drawBoard')
 
 module.exports = (options, io) => {
   const { state, messages } = options
   const { write } = io
 
-  write(display.board(state))
+  write(drawBoard(state))
   write(messages.ending)
 }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,14 +1,14 @@
 const play = require('./play')
 
-const start = (options, io) => {
-  const { messages } = options
+const start = (game, io) => {
+  const { messages } = game
   const { write } = io
 
   write(messages.title)
   write(messages.intro)
   write(messages.instructions)
 
-  play(options, io)
+  play(game, io)
 }
 
 module.exports = start

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,6 +1,6 @@
 const play = require('./play')
 
-const start = (options, updater, io) => {
+const start = (options, io) => {
   const { messages } = options
   const { write } = io
 
@@ -8,7 +8,7 @@ const start = (options, updater, io) => {
   write(messages.intro)
   write(messages.instructions)
 
-  play(options, updater, io)
+  play(options, io)
 }
 
 module.exports = start

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,4 +1,4 @@
-const makeMove = require('./makeMove')
+const play = require('./play')
 
 const start = (options, updater, io) => {
   const { messages } = options
@@ -8,7 +8,7 @@ const start = (options, updater, io) => {
   write(messages.intro)
   write(messages.instructions)
 
-  makeMove(options, updater, io)
+  play(options, updater, io)
 }
 
 module.exports = start

--- a/src/cli/makeMove.js
+++ b/src/cli/makeMove.js
@@ -1,4 +1,4 @@
-const display = require('./display')
+const drawBoard = require('./drawBoard')
 const getMove = require('./getMove')
 const gameOver = require('./gameOver')
 
@@ -10,8 +10,7 @@ const makeMove = async (options, updater, io) => {
     return gameOver(options, io)
   }
 
-  const newline = '\n'
-  write(newline + display.board(state) + newline)
+  write(drawBoard(state))
 
   const position = await getMove(input, output, messages.turn)
 

--- a/src/cli/play.js
+++ b/src/cli/play.js
@@ -2,7 +2,9 @@ const drawBoard = require('./drawBoard')
 const getMove = require('./getMove')
 const gameOver = require('./gameOver')
 
-const play = async (options, updater, io) => {
+const { update } = require('../game/')
+
+const play = async (options, io) => {
   const { board, messages } = options
   const { input, output, write } = io
 
@@ -14,7 +16,7 @@ const play = async (options, updater, io) => {
 
   const position = await getMove(input, output, messages.turn)
 
-  play(updater(position, options), updater, io)
+  play(update(position, options), io)
 }
 
 const gameIsOver = ({ isActive }) => !isActive

--- a/src/cli/play.js
+++ b/src/cli/play.js
@@ -4,19 +4,19 @@ const gameOver = require('./gameOver')
 
 const { update } = require('../game/')
 
-const play = async (options, io) => {
-  const { board, messages } = options
+const play = async (game, io) => {
+  const { board, messages } = game
   const { input, output, write } = io
 
-  if (gameIsOver(options)) {
-    return gameOver(options, io)
+  if (gameIsOver(game)) {
+    return gameOver(game, io)
   }
 
   write(drawBoard(board))
 
   const position = await getMove(input, output, messages.turn)
 
-  play(update(position, options), io)
+  play(update(position, game), io)
 }
 
 const gameIsOver = ({ isActive }) => !isActive

--- a/src/cli/play.js
+++ b/src/cli/play.js
@@ -3,14 +3,14 @@ const getMove = require('./getMove')
 const gameOver = require('./gameOver')
 
 const play = async (options, updater, io) => {
-  const { state, messages } = options
+  const { board, messages } = options
   const { input, output, write } = io
 
   if (gameIsOver(options)) {
     return gameOver(options, io)
   }
 
-  write(drawBoard(state))
+  write(drawBoard(board))
 
   const position = await getMove(input, output, messages.turn)
 

--- a/src/cli/play.js
+++ b/src/cli/play.js
@@ -3,10 +3,10 @@ const getMove = require('./getMove')
 const gameOver = require('./gameOver')
 
 const play = async (options, updater, io) => {
-  const { isActive, state, messages } = options
+  const { state, messages } = options
   const { input, output, write } = io
 
-  if (!isActive) {
+  if (gameIsOver(options)) {
     return gameOver(options, io)
   }
 
@@ -16,5 +16,7 @@ const play = async (options, updater, io) => {
 
   play(updater(position, options), updater, io)
 }
+
+const gameIsOver = ({ isActive }) => !isActive
 
 module.exports = play

--- a/src/cli/play.js
+++ b/src/cli/play.js
@@ -2,7 +2,7 @@ const drawBoard = require('./drawBoard')
 const getMove = require('./getMove')
 const gameOver = require('./gameOver')
 
-const makeMove = async (options, updater, io) => {
+const play = async (options, updater, io) => {
   const { isActive, state, messages } = options
   const { input, output, write } = io
 
@@ -14,7 +14,7 @@ const makeMove = async (options, updater, io) => {
 
   const position = await getMove(input, output, messages.turn)
 
-  makeMove(updater(position, options), updater, io)
+  play(updater(position, options), updater, io)
 }
 
-module.exports = makeMove
+module.exports = play

--- a/src/cli/utils/state.js
+++ b/src/cli/utils/state.js
@@ -1,4 +1,4 @@
-const get = (state, position) => state[toArrayIndex(position)] || position
+const get = (board, position) => board[toArrayIndex(position)] || position
 
 const toArrayIndex = number => number - 1
 

--- a/src/game/ai/minimax.js
+++ b/src/game/ai/minimax.js
@@ -1,4 +1,4 @@
-const board = require('../board')
+const referee = require('../referee')
 const {
   bestPositionReducer,
   maximumReducer,
@@ -9,54 +9,54 @@ const WINNING_SCORE = 10
 const LOSING_SCORE = -10
 const DRAW_SCORE = 0
 
-const initialise = (state, maximisingPlayer) => {
-  if (board.available(state).length === 0) {
-    throw new TypeError('Must supply a board state that is not full')
+const initialise = (board, maximisingPlayer) => {
+  if (referee.available(board).length === 0) {
+    throw new TypeError('Must supply a board board that is not full')
   }
 
   const players = calculatePlayers(maximisingPlayer)
 
-  return board
-    .available(state)
+  return referee
+    .available(board)
     .map(position => [
       position,
-      scoreMax(board.update(state, position, players.maximiser), players),
+      scoreMax(referee.update(board, position, players.maximiser), players),
     ])
     .reduce(bestPositionReducer, { position: null, value: -100000 })
 }
 
-const scoreMax = (state, players) => {
-  if (board.hasWinner(state)) {
-    return WINNING_SCORE + board.available(state).length
+const scoreMax = (board, players) => {
+  if (referee.hasWinner(board)) {
+    return WINNING_SCORE + referee.available(board).length
   }
 
-  if (board.available(state).length === 0) {
+  if (referee.available(board).length === 0) {
     return DRAW_SCORE
   }
 
-  const scores = board
-    .available(state)
+  const scores = referee
+    .available(board)
     .map(position =>
-      scoreMin(board.update(state, position, players.minimiser), players)
+      scoreMin(referee.update(board, position, players.minimiser), players)
     )
     .reduce(minimumReducer, +1000)
 
   return scores
 }
 
-const scoreMin = (state, players) => {
-  if (board.hasWinner(state)) {
-    return LOSING_SCORE - board.available(state).length
+const scoreMin = (board, players) => {
+  if (referee.hasWinner(board)) {
+    return LOSING_SCORE - referee.available(board).length
   }
 
-  if (board.available(state).length === 0) {
+  if (referee.available(board).length === 0) {
     return DRAW_SCORE
   }
 
-  const scores = board
-    .available(state)
+  const scores = referee
+    .available(board)
     .map(position =>
-      scoreMax(board.update(state, position, players.maximiser), players)
+      scoreMax(referee.update(board, position, players.maximiser), players)
     )
     .reduce(maximumReducer, -1000)
 

--- a/src/game/init.js
+++ b/src/game/init.js
@@ -1,9 +1,9 @@
 const messages = require('./messages')
-const board = require('./board')
+const referee = require('./referee')
 
 module.exports = (mode = 'human') => ({
   isActive: true,
-  state: board.newState(),
+  board: referee.create(),
   messages: {
     title: messages.title(),
     intro: messages.intro(),

--- a/src/game/referee.js
+++ b/src/game/referee.js
@@ -1,4 +1,4 @@
-const newState = (totalSquares = '9') => {
+const create = (totalSquares = '9') => {
   const emptySquare = null
   return Array.from({ length: totalSquares }).fill(emptySquare)
 }
@@ -55,7 +55,7 @@ const available = board => {
 }
 
 module.exports = {
-  newState,
+  create,
   get,
   update,
   hasWinner,

--- a/src/game/update.js
+++ b/src/game/update.js
@@ -1,11 +1,11 @@
-const board = require('./board')
+const referee = require('./referee')
 const messages = require('./messages')
 const minimax = require('./ai/minimaxPlayer')
 
 const swapPlayer = currentPlayer => (currentPlayer === 'X' ? 'O' : 'X')
 
-const getEndingMessage = (state, currentPlayer) => {
-  if (board.hasWinner(state)) {
+const getEndingMessage = (board, currentPlayer) => {
+  if (referee.hasWinner(board)) {
     return messages.winner(currentPlayer)
   }
 
@@ -13,30 +13,34 @@ const getEndingMessage = (state, currentPlayer) => {
 }
 
 const update = (position, options) => {
-  const newState = board.update(options.state, position, options.currentPlayer)
+  const updatedBoard = referee.update(
+    options.board,
+    position,
+    options.currentPlayer
+  )
 
-  if (gameIsOver(newState)) {
-    return gameOver(newState, options.currentPlayer)
+  if (gameIsOver(updatedBoard)) {
+    return gameOver(updatedBoard, options.currentPlayer)
   }
 
   if (options.mode === 'ai' && swapPlayer(options.currentPlayer) === 'O') {
     return update(
-      minimax.chooseMove(board, newState),
-      nextMove(newState, options)
+      minimax.chooseMove(referee, updatedBoard),
+      nextMove(updatedBoard, options)
     )
   }
 
-  return nextMove(newState, options)
+  return nextMove(updatedBoard, options)
 }
 
-const gameIsOver = state =>
-  board.hasWinner(state) || board.available(state).length <= 0
+const gameIsOver = board =>
+  referee.hasWinner(board) || referee.available(board).length <= 0
 
-const nextMove = (state, options) => {
+const nextMove = (board, options) => {
   const nextPlayer = swapPlayer(options.currentPlayer)
   return {
     ...options,
-    state,
+    board,
     currentPlayer: nextPlayer,
     isActive: true,
     messages: {
@@ -45,11 +49,11 @@ const nextMove = (state, options) => {
   }
 }
 
-const gameOver = (state, currentPlayer) => ({
-  state,
+const gameOver = (board, currentPlayer) => ({
+  board,
   isActive: false,
   messages: {
-    ending: getEndingMessage(state, currentPlayer),
+    ending: getEndingMessage(board, currentPlayer),
   },
 })
 


### PR DESCRIPTION
This PR renames functions and variables across the project to add clarity, and is the foundation to build towards the error checking user story.

Summary of changes:

- `state` (which represents the board state) is now referenced as `board`.
- `board` (which represented functions that dealt with a board state) is now the `referee` (this name felt fitting as it is the object that ensures the game is progressing properly)
- `display.board` has been renamed to a more straightforward `drawBoard`
- the recursively called `makeMove` function is now simply `play`
- instead of passing the `options` object throughout the functions, it is now referenced as `game` as it essentially contains all of the required game logic. the `game` object is what gets passed between the `cli` and `game` functions. 
- the dependency injection of the `update` function has been removed and is now included directly in the `cli` files that need it. While tighter coupling is normally to be avoided, I felt that the design did not need dependency injection and this only served to make things more confusing - if we end up having multiple functions that can create/assess the game object, then this might be a good point to reintroduce it. 